### PR TITLE
[URL] Error reasons

### DIFF
--- a/Sources/SuperValidator/Helpers/Regex.swift
+++ b/Sources/SuperValidator/Helpers/Regex.swift
@@ -15,6 +15,7 @@ extension String {
 }
 
 internal enum Regex {
+    internal static let url = "((http|https)://)?([(w|W)]{3}+\\.)?+(.)+\\.+[A-Za-z]{2,3}+(\\.)?+(/(.)*)?"
     internal static let emailStrict = "[A-Z0-9a-z\\._%+-]+@([A-Za-z0-9-]+\\.)+[A-Za-z]{2,4}"
     internal static let emailLax = #".+@([A-Za-z0-9]+\\.)+[A-Za-z]{2}[A-Za-z]*"#
 }

--- a/Sources/SuperValidator/Helpers/Regex.swift
+++ b/Sources/SuperValidator/Helpers/Regex.swift
@@ -15,7 +15,7 @@ extension String {
 }
 
 internal enum Regex {
-    internal static let url = "((http|https)://)?([(w|W)]{3}+\\.)?+(.)+\\.+[A-Za-z]{2,3}+(\\.)?+(/(.)*)?"
+    internal static let url = "((http|https|ftp)://)?([(w|W)]{3}+\\.)?+(.)+\\.+[A-Za-z]{2,3}+(\\.)?+(/(.)*)?"
     internal static let emailStrict = "[A-Z0-9a-z\\._%+-]+@([A-Za-z0-9-]+\\.)+[A-Za-z]{2,4}"
     internal static let emailLax = #".+@([A-Za-z0-9]+\\.)+[A-Za-z]{2}[A-Za-z]*"#
 }

--- a/Sources/SuperValidator/SuperValidator.swift
+++ b/Sources/SuperValidator/SuperValidator.swift
@@ -22,7 +22,15 @@ public class SuperValidator {
     ///   - options: url options such as valid protocols, hostname, path.
     /// - Returns: if the url matches the options, return true
     public func isURL(_ string: String, options: Option.URL = .init()) -> Bool {
-        return validateURL(string, options: options)
+        let result = urlValidator(string, options: options)
+        switch result {
+        case .success: return true
+        case .failure: return false
+        }
+    }
+    
+    public func validateURL(_ string: String, options: Option.URL = .init()) -> Result<Void, URLError> {
+        return urlValidator(string, options: options)
     }
 
     /// validate url with social media setting
@@ -31,7 +39,15 @@ public class SuperValidator {
     ///   - socialMedia:enum of social media url option
     /// - Returns: if the url matches the social media url options, return true
     public func isURL(_ string: String, socialMedia: Option.SocialMediaURL) -> Bool {
-        return validateURL(string, options: socialMedia.options)
+        let result = urlValidator(string, options: socialMedia.options)
+        switch result {
+        case .success: return true
+        case .failure: return false
+        }
+    }
+    
+    public func validateURL(_ string: String, socialMedia: Option.SocialMediaURL) -> Result<Void, URLError> {
+        return urlValidator(string, options: socialMedia.options)
     }
 
     // MARK: - FQDN

--- a/Sources/SuperValidator/SuperValidator.swift
+++ b/Sources/SuperValidator/SuperValidator.swift
@@ -19,7 +19,7 @@ public class SuperValidator {
     /// validate url with custom options
     /// - Parameters:
     ///   - string: url string
-    ///   - options: url options such as valid protocols, domain, path.
+    ///   - options: url options such as protocols, domain, path.
     /// - Returns: if the url matches the options, return true
     public func isURL(_ string: String, options: Option.URL = .init()) -> Bool {
         let result = urlValidator(string, options: options)
@@ -28,7 +28,12 @@ public class SuperValidator {
         case .failure: return false
         }
     }
-    
+
+    /// validate url with custom options
+    /// - Parameters:
+    ///   - string: url string
+    ///   - options: url options such as protocols, domain, path.
+    /// - Returns: a success void or failure with error enum
     public func validateURL(_ string: String, options: Option.URL = .init()) -> Result<Void, URLError> {
         return urlValidator(string, options: options)
     }
@@ -46,6 +51,11 @@ public class SuperValidator {
         }
     }
     
+    /// validate url with social media setting
+    /// - Parameters:
+    ///   - string: url string
+    ///   - socialMedia:enum of social media url option
+    /// - Returns: a success void or failure with error enum
     public func validateURL(_ string: String, socialMedia: Option.SocialMediaURL) -> Result<Void, URLError> {
         return urlValidator(string, options: socialMedia.options)
     }

--- a/Sources/SuperValidator/SuperValidator.swift
+++ b/Sources/SuperValidator/SuperValidator.swift
@@ -58,14 +58,6 @@ public class SuperValidator {
     ///   - options: fqdn options
     /// - Returns: if the domain matches the options, return true
     public func isFQDN(_ string: String, options: Option.FQDN = .init()) -> Bool {
-        let result = fqdnValidator(string, options: options)
-        switch result {
-        case .success: return true
-        case .failure: return false
-        }
-    }
-    
-    public func validateFQDN(_ string: String, options: Option.FQDN = .init()) -> Result<Void, FQDNError> {
         return fqdnValidator(string, options: options)
     }
     

--- a/Sources/SuperValidator/SuperValidator.swift
+++ b/Sources/SuperValidator/SuperValidator.swift
@@ -19,7 +19,7 @@ public class SuperValidator {
     /// validate url with custom options
     /// - Parameters:
     ///   - string: url string
-    ///   - options: url options such as valid protocols, hostname, path.
+    ///   - options: url options such as valid protocols, domain, path.
     /// - Returns: if the url matches the options, return true
     public func isURL(_ string: String, options: Option.URL = .init()) -> Bool {
         let result = urlValidator(string, options: options)

--- a/Sources/SuperValidator/SuperValidator.swift
+++ b/Sources/SuperValidator/SuperValidator.swift
@@ -58,7 +58,15 @@ public class SuperValidator {
     ///   - options: fqdn options
     /// - Returns: if the domain matches the options, return true
     public func isFQDN(_ string: String, options: Option.FQDN = .init()) -> Bool {
-        return validateFQDN(string, options: options)
+        let result = fqdnValidator(string, options: options)
+        switch result {
+        case .success: return true
+        case .failure: return false
+        }
+    }
+    
+    public func validateFQDN(_ string: String, options: Option.FQDN = .init()) -> Result<Void, FQDNError> {
+        return fqdnValidator(string, options: options)
     }
     
     // MARK: - Email

--- a/Sources/SuperValidator/Validators/FQDN.swift
+++ b/Sources/SuperValidator/Validators/FQDN.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// MARK: - Option
+
 extension SuperValidator.Option {
     /// Fully Qualified Domain Name
     public struct FQDN {
@@ -31,8 +33,20 @@ extension SuperValidator.Option {
     }
 }
 
+// MARK: - Error
+
 extension SuperValidator {
-    internal func validateFQDN(_ string: String, options: Option.FQDN = .init()) -> Bool {
+    public enum FQDNError: Error, Equatable {
+        case unqualified
+        case invalidTLD
+        case containsWhitespace
+    }
+}
+
+// MARK: - Validator
+
+extension SuperValidator {
+    internal func fqdnValidator(_ string: String, options: Option.FQDN = .init()) -> Result<Void, FQDNError> {
         var _string = string
 
         // Remove the optional trailing dot before checking validity
@@ -48,15 +62,15 @@ extension SuperValidator {
         let parts = _string.components(separatedBy: ".")
 
         if options.requireTLD {
-            guard let tld = parts[safe: parts.count - 1] else { return false }
+            guard let tld = parts[safe: parts.count - 1] else { return .failure(.invalidTLD) }
             // disallow fqdns without tld
             if parts.count < 2 || !tld.matches("([a-z\u{00a1}-\u{ffff}]{2,}|xn[a-z0-9-]{2,})") {
-                return false
+                return .failure(.invalidTLD)
             }
 
             // disallow space
             if tld.matches("\\s") {
-                return false
+                return .failure(.containsWhitespace)
             }
         }
 
@@ -68,19 +82,19 @@ extension SuperValidator {
             }
 
             if !_part.matches("[a-z\u{00a1}-\u{ffff0}0-9-]+") {
-                return false
+                return .failure(.unqualified)
             }
 
             // disallow parts starting or ending with hyphen
             if let first = _part.first, let last = _part.last {
                 if first == "-" || last == "-" {
-                    return false
+                    return .failure(.unqualified)
                 }
             } else {
-                return false
+                return .failure(.unqualified)
             }
         }
 
-        return true
+        return .success(())
     }
 }

--- a/Sources/SuperValidator/Validators/FQDN.swift
+++ b/Sources/SuperValidator/Validators/FQDN.swift
@@ -7,8 +7,6 @@
 
 import Foundation
 
-// MARK: - Option
-
 extension SuperValidator.Option {
     /// Fully Qualified Domain Name
     public struct FQDN {
@@ -33,20 +31,8 @@ extension SuperValidator.Option {
     }
 }
 
-// MARK: - Error
-
 extension SuperValidator {
-    public enum FQDNError: Error, Equatable {
-        case unqualified
-        case invalidTLD
-        case containsWhitespace
-    }
-}
-
-// MARK: - Validator
-
-extension SuperValidator {
-    internal func fqdnValidator(_ string: String, options: Option.FQDN = .init()) -> Result<Void, FQDNError> {
+    internal func fqdnValidator(_ string: String, options: Option.FQDN = .init()) -> Bool {
         var _string = string
 
         // Remove the optional trailing dot before checking validity
@@ -62,15 +48,15 @@ extension SuperValidator {
         let parts = _string.components(separatedBy: ".")
 
         if options.requireTLD {
-            guard let tld = parts[safe: parts.count - 1] else { return .failure(.invalidTLD) }
+            guard let tld = parts[safe: parts.count - 1] else { return false }
             // disallow fqdns without tld
             if parts.count < 2 || !tld.matches("([a-z\u{00a1}-\u{ffff}]{2,}|xn[a-z0-9-]{2,})") {
-                return .failure(.invalidTLD)
+                return false
             }
 
             // disallow space
             if tld.matches("\\s") {
-                return .failure(.containsWhitespace)
+                return false
             }
         }
 
@@ -82,19 +68,19 @@ extension SuperValidator {
             }
 
             if !_part.matches("[a-z\u{00a1}-\u{ffff0}0-9-]+") {
-                return .failure(.unqualified)
+                return false
             }
 
             // disallow parts starting or ending with hyphen
             if let first = _part.first, let last = _part.last {
                 if first == "-" || last == "-" {
-                    return .failure(.unqualified)
+                    return false
                 }
             } else {
-                return .failure(.unqualified)
+                return false
             }
         }
 
-        return .success(())
+        return true
     }
 }

--- a/Sources/SuperValidator/Validators/FQDN.swift
+++ b/Sources/SuperValidator/Validators/FQDN.swift
@@ -16,7 +16,12 @@ extension SuperValidator.Option {
         public let allowTrailingDot: Bool
         /// Wildcard DNS record
         public let allowWildcard: Bool
-
+        
+        /// - Parameters:
+        ///    - requireTLD: Top Level Domain
+        ///    - allowUnderscores
+        ///    - allowTrailingDot
+        ///    - allowWildcard:Wildcard DNS record
         public init(
             requireTLD: Bool = true,
             allowUnderscores: Bool = false,

--- a/Sources/SuperValidator/Validators/SocialMediaURL.swift
+++ b/Sources/SuperValidator/Validators/SocialMediaURL.swift
@@ -14,7 +14,7 @@ extension SuperValidator.Option {
         case youtube
         case twitter
 
-        private var hostWhitelist: SuperValidator.Option.URL.Host {
+        private var domainWhitelist: SuperValidator.Option.URL.Domain {
             switch self {
             case .instagram:
                 return [#"(www\.)?(instagram\.com)"#]
@@ -48,8 +48,8 @@ extension SuperValidator.Option {
                 requireValidProtocol: true,
                 paths: self.paths,
                 allowQueryComponents: false,
-                hostWhitelist: self.hostWhitelist,
-                hostBlacklist: [],
+                domainWhitelist: self.domainWhitelist,
+                domainBlacklist: [],
                 fqdn: .init()
             )
         }

--- a/Sources/SuperValidator/Validators/SocialMediaURL.swift
+++ b/Sources/SuperValidator/Validators/SocialMediaURL.swift
@@ -50,7 +50,7 @@ extension SuperValidator.Option {
                 allowQueryComponents: false,
                 hostWhitelist: self.hostWhitelist,
                 hostBlacklist: [],
-                fdqn: .init()
+                fqdn: .init()
             )
         }
     }

--- a/Sources/SuperValidator/Validators/URL.swift
+++ b/Sources/SuperValidator/Validators/URL.swift
@@ -15,15 +15,15 @@ extension SuperValidator.Option {
         public typealias Protocols = [String]
         public typealias Path = [String]
         public typealias Domain = [String]
-        /// valid protocol ( e.g https. http, ftp )
+        /// valid protocol [https. http, ftp]
         public let protocols: Protocols
-        /// if true, url must have protocol
+        /// if set to true, url must have protocol
         public let requireProtocol: Bool
-        /// protocol must be the same as one of valid protocol listed in protocols constant
+        /// protocol must be the same as one of the valid protocol listed in protocols parameter
         public let requireValidProtocol: Bool
-        /// path ( e.g /user/edit/{userID} )
+        /// url path ( e.g /user/edit/{userID} )
         public let paths: Path
-        /// query ( e.g page=1&sort=asc )
+        /// if set to true, allow query components ( e.g page=1&sort=asc )
         public let allowQueryComponents: Bool
         /// domain must be the same as one of whitelisted domain
         public let domainWhitelist: Domain
@@ -31,7 +31,16 @@ extension SuperValidator.Option {
         public let domainBlacklist: Domain
         /// Fully Qualified Domain Name`
         public let fqdn: FQDN
-
+        
+        /// - Parameters:
+        ///    - protocols: valid protocol [https. http, ftp]
+        ///    - requireProtocol: if set to true, url must have protocol
+        ///    - requireValidProtocol: protocol must be the same as one of the valid protocol listed in protocols parameter
+        ///    - paths: url path ( e.g /user/edit/{userID} )
+        ///    - allowQueryComponents: if set to true, allow query components ( e.g page=1&sort=asc )
+        ///    - domainWhitelist: domain must be the same as one of whitelisted domain
+        ///    - domainBlacklist: domain can't be the same as one of blacklisted domain
+        ///    - fqdn: Fully Qualified Domain Name
         public init(
             protocols: Protocols = ["https", "http", "ftp"],
             requireProtocol: Bool = false,
@@ -77,7 +86,7 @@ extension SuperValidator {
             case .containsWhitespace, .containsQueryComponents, .invalidProtocol,
                  .noProtocol, .invalidPath, .invalidDomain, .blacklistedDomain,
                  .invalidFQDN:
-                return nil
+                return "Please enter a valid url"
             }
         }
     }

--- a/Sources/SuperValidator/Validators/URL.swift
+++ b/Sources/SuperValidator/Validators/URL.swift
@@ -68,7 +68,7 @@ extension SuperValidator {
         /// domain not contained in domainWhitelist parameter
         case invalidDomain
         case blacklistedDomain
-        case fqdn(FQDNError)
+        case invalidFQDN
         
         public var errorDescription: String? {
             switch self {
@@ -76,7 +76,7 @@ extension SuperValidator {
                 return "Please enter an url"
             case .containsWhitespace, .containsQueryComponents, .invalidProtocol,
                  .noProtocol, .invalidPath, .invalidDomain, .blacklistedDomain,
-                 .fqdn:
+                 .invalidFQDN:
                 return nil
             }
         }
@@ -145,13 +145,8 @@ extension SuperValidator {
             return .failure(.blacklistedDomain)
         }
         
-        let fqdnResult = validateFQDN(domain, options: options.fqdn)
-        if case let .failure(error) = fqdnResult {
-            if error == .containsWhitespace {
-                return .failure(.containsWhitespace)
-            } else {
-                return .failure(.fqdn(error))
-            }
+        if !isFQDN(domain, options: options.fqdn) {
+            return .failure(.invalidFQDN)
         }
 
         return .success(())

--- a/Sources/SuperValidator/Validators/URL.swift
+++ b/Sources/SuperValidator/Validators/URL.swift
@@ -59,6 +59,7 @@ extension SuperValidator.Option {
 extension SuperValidator {
     public enum URLError: Error, LocalizedError {
         case notUrl
+        case containsWhitespace
         case containsQueryComponents
         case invalidProtocol
         case noProtocol
@@ -70,8 +71,8 @@ extension SuperValidator {
             switch self {
             case .notUrl:
                 return "Please enter an url"
-            case .containsQueryComponents, .invalidProtocol, .noProtocol,
-                 .invalidPath, .invalidHost, .blacklistedHost:
+            case .containsWhitespace, .containsQueryComponents, .invalidProtocol,
+                 .noProtocol, .invalidPath, .invalidHost, .blacklistedHost:
                 return nil
             }
         }
@@ -82,7 +83,9 @@ extension SuperValidator {
 
 extension SuperValidator {
     internal func urlValidator(_ string: String, options: Option.URL) -> Result<Void, URLError> {
-        guard string.isNotEmpty, !string.containsWhitespace else { return .failure(.notUrl) }
+        guard string.isNotEmpty, string.matches(Regex.url) else { return .failure(.notUrl) }
+        guard !string.containsWhitespace else { return .failure(.containsWhitespace) }
+        
         var url = string
 
         if !options.allowQueryComponents, url.contains("?") || url.contains("&") {

--- a/Sources/SuperValidator/Validators/URL.swift
+++ b/Sources/SuperValidator/Validators/URL.swift
@@ -61,9 +61,11 @@ extension SuperValidator {
         case notUrl
         case containsWhitespace
         case containsQueryComponents
+        /// protocol not contained in protocols parameter
         case invalidProtocol
         case noProtocol
         case invalidPath
+        /// host not contained in hostWhitelist parameter
         case invalidHost
         case blacklistedHost
         

--- a/Sources/SuperValidator/Validators/URL.swift
+++ b/Sources/SuperValidator/Validators/URL.swift
@@ -83,8 +83,9 @@ extension SuperValidator {
 
 extension SuperValidator {
     internal func urlValidator(_ string: String, options: Option.URL) -> Result<Void, URLError> {
-        guard string.isNotEmpty, string.matches(Regex.url) else { return .failure(.notUrl) }
+        guard string.isNotEmpty else { return .failure(.notUrl) }
         guard !string.containsWhitespace else { return .failure(.containsWhitespace) }
+        guard string.matches(Regex.url) else { return .failure(.notUrl) }
         
         var url = string
 

--- a/Tests/SuperValidatorTests/FQDNValidatorTests.swift
+++ b/Tests/SuperValidatorTests/FQDNValidatorTests.swift
@@ -1,0 +1,68 @@
+//
+//  FQDNValidatorTests.swift
+//  
+//
+//  Created by alvin.pratama on 31/03/22.
+//
+
+import XCTest
+
+@testable import SuperValidator
+
+internal final class FQDNValidatorTests: XCTestCase {
+    private let validator = SuperValidator.shared
+    
+    internal func testValidFQDN() {
+        let domain = "www.tokopedia.com"
+        let isFQDN = validator.isFQDN(domain)
+        XCTAssertTrue(isFQDN)
+    }
+    
+    internal func testFQDNWithInvalidTLD() {
+        let domain = "www.tokopedia.c"
+        let isFQDN = validator.isFQDN(domain)
+        XCTAssertFalse(isFQDN)
+    }
+    
+    internal func testFQDNWithHypen() {
+        let domain = "www.tokopedia-.com"
+        let isFQDN = validator.isFQDN(domain)
+        XCTAssertFalse(isFQDN)
+    }
+    
+    internal func testFQDNWithUnderscore() {
+        let domain = "www.tokopedia_.com"
+        let isFQDN = validator.isFQDN(domain)
+        XCTAssertFalse(isFQDN)
+    }
+    
+    internal func testFQDNWithUnderscoreAllowed() {
+        let domain = "www.tokopedia_.com"
+        let isFQDN = validator.isFQDN(domain, options: .init(allowUnderscores: true))
+        XCTAssertTrue(isFQDN)
+    }
+    
+    internal func testFQDNWithTrailingDot() {
+        let domain = "www.tokopedia.com."
+        let isFQDN = validator.isFQDN(domain)
+        XCTAssertFalse(isFQDN)
+    }
+    
+    internal func testFQDNWithTrailingDotAllowed() {
+        let domain = "www.tokopedia.com."
+        let isFQDN = validator.isFQDN(domain, options: .init(allowTrailingDot: true))
+        XCTAssertTrue(isFQDN)
+    }
+    
+    internal func testFQDNAllowWildcard() {
+        let domain = "*.tokopedia.com"
+        let isFQDN = validator.isFQDN(domain, options: .init(allowWildcard: true))
+        XCTAssertTrue(isFQDN)
+    }
+    
+    internal func testFQDNDiallowWildcard() {
+        let domain = "*.tokopedia.com"
+        let isFQDN = validator.isFQDN(domain)
+        XCTAssertFalse(isFQDN)
+    }
+}

--- a/Tests/SuperValidatorTests/SocialMediaURLValidatorTests.swift
+++ b/Tests/SuperValidatorTests/SocialMediaURLValidatorTests.swift
@@ -62,6 +62,74 @@ internal final class SocialMediaURLValidatorTests: XCTestCase {
         XCTAssertFalse(isURL)
     }
     
+    // MARK: - Instagram + Error Reasons
+    
+    internal func testValidInstagramURL_ErrorReason() {
+        let url = "https://instagram.com/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .instagram)
+        switch result {
+        case .success:
+            XCTAssertTrue(true)
+        case let .failure(error):
+            XCTFail("Expected to be a success but got a failure with \(error)")
+        }
+    }
+    
+    internal func testInstagramURLWithInvalidProtocol_ErrorReason() {
+        let url = "ftp://www.instagram.com/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .instagram)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidProtocol)
+        }
+    }
+
+    internal func testInstagramURLWithInvalidHostname_ErrorReason() {
+        let url = "www.tiktok.com/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .instagram)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidHost)
+        }
+    }
+
+    internal func testInstagramURLWithoutPath_ErrorReason() {
+        let url = "www.instagram.com/"
+        let result = self.validator.validateURL(url, socialMedia: .instagram)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidPath)
+        }
+    }
+
+    internal func testInstagramURLWithInvalidPath_ErrorReason() {
+        let url = "www.instagram.com/user/a"
+        let result = self.validator.validateURL(url, socialMedia: .instagram)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidPath)
+        }
+    }
+
+    internal func testInstagramURLWithWhiteSpace_ErrorReason() {
+        let url = "www. instagram.com/myuser/a"
+        let result = self.validator.validateURL(url, socialMedia: .instagram)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.containsWhitespace)
+        }
+    }
+    
     // MARK: - Tiktok
     
     internal func testValidTiktokURL() {
@@ -104,6 +172,74 @@ internal final class SocialMediaURLValidatorTests: XCTestCase {
         let url = "vt.tiktok.com/myus er"
         let isURL = self.validator.isURL(url, socialMedia: .tiktok)
         XCTAssertFalse(isURL)
+    }
+    
+    // MARK: - Tiktok + ErrorReasons
+    
+    internal func testValidTiktokURL_ErrorReason() {
+        let url = "https://vt.tiktok.com/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .tiktok)
+        switch result {
+        case .success:
+            XCTAssertTrue(true)
+        case let .failure(error):
+            XCTFail("Expected to be a success but got a failure with \(error)")
+        }
+    }
+
+    internal func testTiktokURLWithWWW_ErrorReason() {
+        let url = "https://www.vt.tiktok.com/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .tiktok)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidHost)
+        }
+    }
+
+    internal func testTiktokURLWithInvalidProtocol_ErrorReason() {
+        let url = "ftp://vt.tiktok.com/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .tiktok)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidProtocol)
+        }
+    }
+
+    internal func testTiktokURLWithInvalidHostname_ErrorReason() {
+        let url = "invalid.com/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .tiktok)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidHost)
+        }
+    }
+
+    internal func testTiktokURLWithInvalidPath_ErrorReason() {
+        let url = "https://vt.tiktok.com/myuser/a"
+        let result = self.validator.validateURL(url, socialMedia: .tiktok)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidPath)
+        }
+    }
+
+    internal func testTiktokURLWithWhiteSpace_ErrorReason() {
+        let url = "vt.tiktok.com/myus er"
+        let result = self.validator.validateURL(url, socialMedia: .tiktok)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.containsWhitespace)
+        }
     }
     
     // MARK: - Youtube
@@ -174,6 +310,74 @@ internal final class SocialMediaURLValidatorTests: XCTestCase {
         XCTAssertFalse(isURL)
     }
     
+    // MARK: - Youtube + Error Reasons
+    
+    internal func testValidYoutubeURL_ErrorReason() {
+        let url = "https://youtube.com/user/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .youtube)
+        switch result {
+        case .success:
+            XCTAssertTrue(true)
+        case let .failure(error):
+            XCTFail("Expected to be a success but got a failure with \(error)")
+        }
+    }
+    
+    internal func testYoutubeURLWithInvalidProtocol_ErrorReason() {
+        let url = "ftp://www.youtube.com/user/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .youtube)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidProtocol)
+        }
+    }
+    
+    internal func testYoutubeURLWithInvalidHostname_ErrorReason() {
+        let url = "www.youtuber.com/user/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .youtube)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidHost)
+        }
+    }
+    
+    internal func testYoutubeURLInvalidPath_ErrorReason() {
+        let url = "www.youtube.com/profile/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .youtube)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidPath)
+        }
+    }
+    
+    internal func testYoutubeURLWithInvalidPath2_ErrorReason() {
+        let url = "www.youtube.com/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .youtube)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidPath)
+        }
+    }
+    
+    internal func testYoutubeURLWithWhiteSpace_ErrorReason() {
+        let url = "www.youtube.com/myus er"
+        let result = self.validator.validateURL(url, socialMedia: .youtube)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.containsWhitespace)
+        }
+    }
+    
     // MARK: - Twitter
     
     internal func testValidTwitterURL() {
@@ -222,5 +426,73 @@ internal final class SocialMediaURLValidatorTests: XCTestCase {
         let url = "www.twitter.c om/myuser"
         let isURL = self.validator.isURL(url, socialMedia: .twitter)
         XCTAssertFalse(isURL)
+    }
+    
+    // MARK: - Twitter + Error Reasons
+    
+    internal func testValidTwitterURL_ErrorReason() {
+        let url = "https://twitter.com/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .twitter)
+        switch result {
+        case .success:
+            XCTAssertTrue(true)
+        case let .failure(error):
+            XCTFail("Expected to be a success but got a failure with \(error)")
+        }
+    }
+    
+    internal func testTwitterURLWithInvalidProtocol_ErrorReason() {
+        let url = "ftp://www.twitter.com/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .twitter)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidProtocol)
+        }
+    }
+    
+    internal func testTwitterURLWithInvalidHostname_ErrorReason() {
+        let url = "www.twitter.co.id/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .twitter)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidHost)
+        }
+    }
+    
+    internal func testTwitterURLWithoutPath_ErrorReason() {
+        let url = "https://twitter.com/"
+        let result = self.validator.validateURL(url, socialMedia: .twitter)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidPath)
+        }
+    }
+    
+    internal func testTwitterURLWithInvalidPath_ErrorReason() {
+        let url = "www.twitter.com/user/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .twitter)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidPath)
+        }
+    }
+    
+    internal func testTwitterURLWithWhiteSpace_ErrorReason() {
+        let url = "www.twitter.c om/myuser"
+        let result = self.validator.validateURL(url, socialMedia: .twitter)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.containsWhitespace)
+        }
     }
 }

--- a/Tests/SuperValidatorTests/SocialMediaURLValidatorTests.swift
+++ b/Tests/SuperValidatorTests/SocialMediaURLValidatorTests.swift
@@ -38,7 +38,7 @@ internal final class SocialMediaURLValidatorTests: XCTestCase {
         XCTAssertFalse(isURL)
     }
     
-    internal func testInstagramURLWithInvalidHostname() {
+    internal func testInstagramURLWithInvalidDomain() {
         let url = "www.tiktok.com/myuser"
         let isURL = self.validator.isURL(url, socialMedia: .instagram)
         XCTAssertFalse(isURL)
@@ -86,14 +86,14 @@ internal final class SocialMediaURLValidatorTests: XCTestCase {
         }
     }
 
-    internal func testInstagramURLWithInvalidHostname_ErrorReason() {
+    internal func testInstagramURLWithInvalidDomain_ErrorReason() {
         let url = "www.tiktok.com/myuser"
         let result = self.validator.validateURL(url, socialMedia: .instagram)
         switch result {
         case .success:
             XCTFail("Expected to be a failure but got a success")
         case let .failure(error):
-            XCTAssertEqual(error, SuperValidator.URLError.invalidHost)
+            XCTAssertEqual(error, SuperValidator.URLError.invalidDomain)
         }
     }
 
@@ -156,7 +156,7 @@ internal final class SocialMediaURLValidatorTests: XCTestCase {
         XCTAssertFalse(isURL)
     }
     
-    internal func testTiktokURLWithInvalidHostname() {
+    internal func testTiktokURLWithInvalidDomain() {
         let url = "invalid.com/myuser"
         let isURL = self.validator.isURL(url, socialMedia: .tiktok)
         XCTAssertFalse(isURL)
@@ -194,7 +194,7 @@ internal final class SocialMediaURLValidatorTests: XCTestCase {
         case .success:
             XCTFail("Expected to be a failure but got a success")
         case let .failure(error):
-            XCTAssertEqual(error, SuperValidator.URLError.invalidHost)
+            XCTAssertEqual(error, SuperValidator.URLError.invalidDomain)
         }
     }
 
@@ -209,14 +209,14 @@ internal final class SocialMediaURLValidatorTests: XCTestCase {
         }
     }
 
-    internal func testTiktokURLWithInvalidHostname_ErrorReason() {
+    internal func testTiktokURLWithInvalidDomain_ErrorReason() {
         let url = "invalid.com/myuser"
         let result = self.validator.validateURL(url, socialMedia: .tiktok)
         switch result {
         case .success:
             XCTFail("Expected to be a failure but got a success")
         case let .failure(error):
-            XCTAssertEqual(error, SuperValidator.URLError.invalidHost)
+            XCTAssertEqual(error, SuperValidator.URLError.invalidDomain)
         }
     }
 
@@ -286,7 +286,7 @@ internal final class SocialMediaURLValidatorTests: XCTestCase {
         XCTAssertFalse(isURL)
     }
     
-    internal func testYoutubeURLWithInvalidHostname() {
+    internal func testYoutubeURLWithInvalidDomain() {
         let url = "www.youtuber.com/user/myuser"
         let isURL = self.validator.isURL(url, socialMedia: .youtube)
         XCTAssertFalse(isURL)
@@ -334,14 +334,14 @@ internal final class SocialMediaURLValidatorTests: XCTestCase {
         }
     }
     
-    internal func testYoutubeURLWithInvalidHostname_ErrorReason() {
+    internal func testYoutubeURLWithInvalidDomain_ErrorReason() {
         let url = "www.youtuber.com/user/myuser"
         let result = self.validator.validateURL(url, socialMedia: .youtube)
         switch result {
         case .success:
             XCTFail("Expected to be a failure but got a success")
         case let .failure(error):
-            XCTAssertEqual(error, SuperValidator.URLError.invalidHost)
+            XCTAssertEqual(error, SuperValidator.URLError.invalidDomain)
         }
     }
     
@@ -404,7 +404,7 @@ internal final class SocialMediaURLValidatorTests: XCTestCase {
         XCTAssertFalse(isURL)
     }
     
-    internal func testTwitterURLWithInvalidHostname() {
+    internal func testTwitterURLWithInvalidDomain() {
         let url = "www.twitter.co.id/myuser"
         let isURL = self.validator.isURL(url, socialMedia: .twitter)
         XCTAssertFalse(isURL)
@@ -452,14 +452,14 @@ internal final class SocialMediaURLValidatorTests: XCTestCase {
         }
     }
     
-    internal func testTwitterURLWithInvalidHostname_ErrorReason() {
+    internal func testTwitterURLWithInvalidDomain_ErrorReason() {
         let url = "www.twitter.co.id/myuser"
         let result = self.validator.validateURL(url, socialMedia: .twitter)
         switch result {
         case .success:
             XCTFail("Expected to be a failure but got a success")
         case let .failure(error):
-            XCTAssertEqual(error, SuperValidator.URLError.invalidHost)
+            XCTAssertEqual(error, SuperValidator.URLError.invalidDomain)
         }
     }
     

--- a/Tests/SuperValidatorTests/URLValidatorTests.swift
+++ b/Tests/SuperValidatorTests/URLValidatorTests.swift
@@ -15,7 +15,13 @@ internal final class URLValidatorTests: XCTestCase {
     // MARK: - Default Options
     
     internal func testValidURL_UseDefaultOptions() {
-        let url = "https://www.example.com/path/test"
+        let url = "https://www.example.com/path/test?myID=123&myName=test#Test"
+        let isURL = self.validator.isURL(url)
+        XCTAssertTrue(isURL)
+    }
+    
+    internal func testValidURLWithFTPProtocol_UseDefaultOptions() {
+        let url = "ftp://www.example.com/path/test"
         let isURL = self.validator.isURL(url)
         XCTAssertTrue(isURL)
     }
@@ -118,5 +124,126 @@ internal final class URLValidatorTests: XCTestCase {
         let blacklistedURL = "https://www.blacklisted.com/shop/test"
         let isBlacklistedURL = self.validator.isURL(blacklistedURL, options: blacklistedOptions)
         XCTAssertFalse(isBlacklistedURL)
+    }
+    
+    // MARK: - Error Reasons
+    
+    internal func testValidURL_ErrorReason() {
+        let url = "https://www.tokopedia.com/shop/test"
+        let result = self.validator.validateURL(url, options: customOptions)
+        switch result {
+        case .success:
+            XCTAssertTrue(true)
+        case let .failure(error):
+            XCTFail("Expected to be a success but got a failure with \(error)")
+        }
+    }
+    
+    internal func testNotURL_ErrorReason() {
+        let url = "asd."
+        let result = self.validator.validateURL(url, options: customOptions)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.notUrl)
+        }
+    }
+    
+    internal func testURLWithWhitespace_ErrorReason() {
+        let url = "https://www.tokopedia.com/sh op/test"
+        let result = self.validator.validateURL(url, options: customOptions)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.containsWhitespace)
+        }
+    }
+
+    internal func testURLWithInvalidProtocol_ErrorReason() {
+        let url = "ftp://tokopedia.com/shop/test"
+        let result = self.validator.validateURL(url, options: customOptions)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidProtocol)
+        }
+    }
+
+    internal func testURLWithoutProtocol_ErrorReason() {
+        let url = "www.tokopedia.com/shop/test"
+        let result = self.validator.validateURL(url, options: customOptions)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.noProtocol)
+        }
+    }
+
+    internal func testURLWithInvalidHostname_ErrorReason() {
+        let url = "https://www.example.com/shop/test"
+        let result = self.validator.validateURL(url, options: customOptions)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidHost)
+        }
+    }
+
+    internal func testURLWithInvalidPath_ErrorReason() {
+        let url = "https://www.tokopedia.com/product/test"
+        let result = self.validator.validateURL(url, options: customOptions)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.invalidPath)
+        }
+    }
+    
+    internal func testURLWithQueryComponents_ErrorReason() {
+        let url = "https://www.tokopedia.com/product/test?productID=123#Desk"
+        let result = self.validator.validateURL(url, options: customOptions)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.containsQueryComponents)
+        }
+    }
+
+    internal func testURLWithBlacklistedHostname_ErrorReason() {
+        let blacklistedOptions: SuperValidator.Option.URL = .init(
+            protocols: ["https", "http"],
+            requireProtocol: false,
+            requireValidProtocol: true,
+            paths: [],
+            allowQueryComponents: false,
+            hostWhitelist: [],
+            hostBlacklist: [#"(www\.)?(blacklisted\.com)"#],
+            fdqn: .init()
+        )
+
+        let url = "https://www.tokopedia.com/product/test"
+        let result = self.validator.validateURL(url, options: blacklistedOptions)
+        switch result {
+        case .success:
+            XCTAssertTrue(true)
+        case let .failure(error):
+            XCTFail("Expected to be a success but got a failure with \(error)")
+        }
+
+        let blacklistedURL = "https://www.blacklisted.com/shop/test"
+        let blacklistedResult = self.validator.validateURL(blacklistedURL, options: blacklistedOptions)
+        switch blacklistedResult {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.blacklistedHost)
+        }
     }
 }

--- a/Tests/SuperValidatorTests/URLValidatorTests.swift
+++ b/Tests/SuperValidatorTests/URLValidatorTests.swift
@@ -66,7 +66,7 @@ internal final class URLValidatorTests: XCTestCase {
         allowQueryComponents: false,
         hostWhitelist: [#"(www\.)?(tokopedia\.com)"#],
         hostBlacklist: [],
-        fdqn: .init()
+        fqdn: .init()
     )
     
     internal func testValidURL_UseCustomOptions() {
@@ -114,7 +114,7 @@ internal final class URLValidatorTests: XCTestCase {
             allowQueryComponents: false,
             hostWhitelist: [],
             hostBlacklist: [#"(www\.)?(blacklisted\.com)"#],
-            fdqn: .init()
+            fqdn: .init()
         )
         
         let url = "https://www.tokopedia.com/product/test"
@@ -225,7 +225,7 @@ internal final class URLValidatorTests: XCTestCase {
             allowQueryComponents: false,
             hostWhitelist: [],
             hostBlacklist: [#"(www\.)?(blacklisted\.com)"#],
-            fdqn: .init()
+            fqdn: .init()
         )
 
         let url = "https://www.tokopedia.com/product/test"

--- a/Tests/SuperValidatorTests/URLValidatorTests.swift
+++ b/Tests/SuperValidatorTests/URLValidatorTests.swift
@@ -64,8 +64,8 @@ internal final class URLValidatorTests: XCTestCase {
         requireValidProtocol: true,
         paths: ["/shop/{shopSlug}"],
         allowQueryComponents: false,
-        hostWhitelist: [#"(www\.)?(tokopedia\.com)"#],
-        hostBlacklist: [],
+        domainWhitelist: [#"(www\.)?(tokopedia\.com)"#],
+        domainBlacklist: [],
         fqdn: .init()
     )
     
@@ -93,7 +93,7 @@ internal final class URLValidatorTests: XCTestCase {
         XCTAssertFalse(isURL)
     }
     
-    internal func testURLWithInvalidHostname_UseCustomOptions() {
+    internal func testURLWithInvalidDomain_UseCustomOptions() {
         let url = "https://www.example.com/shop/test"
         let isURL = self.validator.isURL(url, options: customOptions)
         XCTAssertFalse(isURL)
@@ -105,15 +105,15 @@ internal final class URLValidatorTests: XCTestCase {
         XCTAssertFalse(isURL)
     }
     
-    internal func testURLWithBlacklistedHostname_UseCustomOptions() {
+    internal func testURLWithBlacklistedDomain_UseCustomOptions() {
         let blacklistedOptions: SuperValidator.Option.URL = .init(
             protocols: ["https", "http"],
             requireProtocol: false,
             requireValidProtocol: true,
             paths: [],
             allowQueryComponents: false,
-            hostWhitelist: [],
-            hostBlacklist: [#"(www\.)?(blacklisted\.com)"#],
+            domainWhitelist: [],
+            domainBlacklist: [#"(www\.)?(blacklisted\.com)"#],
             fqdn: .init()
         )
         
@@ -183,14 +183,14 @@ internal final class URLValidatorTests: XCTestCase {
         }
     }
 
-    internal func testURLWithInvalidHostname_ErrorReason() {
+    internal func testURLWithInvalidDomain_ErrorReason() {
         let url = "https://www.example.com/shop/test"
         let result = self.validator.validateURL(url, options: customOptions)
         switch result {
         case .success:
             XCTFail("Expected to be a failure but got a success")
         case let .failure(error):
-            XCTAssertEqual(error, SuperValidator.URLError.invalidHost)
+            XCTAssertEqual(error, SuperValidator.URLError.invalidDomain)
         }
     }
 
@@ -216,15 +216,15 @@ internal final class URLValidatorTests: XCTestCase {
         }
     }
 
-    internal func testURLWithBlacklistedHostname_ErrorReason() {
+    internal func testURLWithBlacklistedDomain_ErrorReason() {
         let blacklistedOptions: SuperValidator.Option.URL = .init(
             protocols: ["https", "http"],
             requireProtocol: false,
             requireValidProtocol: true,
             paths: [],
             allowQueryComponents: false,
-            hostWhitelist: [],
-            hostBlacklist: [#"(www\.)?(blacklisted\.com)"#],
+            domainWhitelist: [],
+            domainBlacklist: [#"(www\.)?(blacklisted\.com)"#],
             fqdn: .init()
         )
 
@@ -243,7 +243,7 @@ internal final class URLValidatorTests: XCTestCase {
         case .success:
             XCTFail("Expected to be a failure but got a success")
         case let .failure(error):
-            XCTAssertEqual(error, SuperValidator.URLError.blacklistedHost)
+            XCTAssertEqual(error, SuperValidator.URLError.blacklistedDomain)
         }
     }
 }

--- a/Tests/SuperValidatorTests/URLValidatorTests.swift
+++ b/Tests/SuperValidatorTests/URLValidatorTests.swift
@@ -246,4 +246,15 @@ internal final class URLValidatorTests: XCTestCase {
             XCTAssertEqual(error, SuperValidator.URLError.blacklistedDomain)
         }
     }
+    
+    internal func testUsingApplink_ErrorReason() {
+        let url = "tokopedia://home"
+        let result = self.validator.validateURL(url)
+        switch result {
+        case .success:
+            XCTFail("Expected to be a failure but got a success")
+        case let .failure(error):
+            XCTAssertEqual(error, SuperValidator.URLError.notUrl)
+        }
+    }
 }


### PR DESCRIPTION
Url validator error reasons

```swift
public enum URLError: Error, LocalizedError, Equatable {
   case notUrl
   case containsWhitespace
   case containsQueryComponents
   case invalidProtocol // protocol not contained in protocols parameter
   case noProtocol
   case invalidPath
   case invalidDomain // domain not contained in domainWhitelist parameter
   case blacklistedDomain
   case invalidFQDN
}
```

Function 
```swift
public func validateURL(_ string: String, socialMedia: Option.URL) -> Result<Void, URLError>
```

How to use
```swift
let url = "https://www.tokopedia.com/shop/test"
let result = self.validator.validateURL(url, options: customOptions)
switch result {
   case .success:
      // do something
   case let .failure(error):
      switch error { ... }
   }
}
```


Other changes:
- Change `host` to `domain`