### PR TITLE
[URL] Fix regex url validation

### DIFF
--- a/Sources/SuperValidator/Helpers/Regex.swift
+++ b/Sources/SuperValidator/Helpers/Regex.swift
@@ -18,7 +18,7 @@ extension String {
 }
 
 internal enum Regex {
-    internal static let url = "((http|https|ftp)://)?([(w|W)]{3}+\\.)?+(.)+\\.+[A-Za-z]+(\\.)?+(/(.)*)?"
+    internal static let url = "((http|https|ftp)://)?([(w|W)]{3}+\\.)?+(.)+\\.+[A-Za-z]{2,63}+(\\.)?+(/(.)*)?"
     internal static let emailStrict = "[A-Z0-9a-z\\._%+-]+@([A-Za-z0-9-]+\\.)+[A-Za-z]{2,4}"
     internal static let emailLax = #".+@([A-Za-z0-9]+\\.)+[A-Za-z]{2}[A-Za-z]*"#
     

--- a/Sources/SuperValidator/Helpers/Regex.swift
+++ b/Sources/SuperValidator/Helpers/Regex.swift
@@ -18,7 +18,7 @@ extension String {
 }
 
 internal enum Regex {
-    internal static let url = "((http|https|ftp)://)?([(w|W)]{3}+\\.)?+(.)+\\.+[A-Za-z]{2,3}+(\\.)?+(/(.)*)?"
+    internal static let url = "((http|https|ftp)://)?([(w|W)]{3}+\\.)?+(.)+\\.+[A-Za-z]+(\\.)?+(/(.)*)?"
     internal static let emailStrict = "[A-Z0-9a-z\\._%+-]+@([A-Za-z0-9-]+\\.)+[A-Za-z]{2,4}"
     internal static let emailLax = #".+@([A-Za-z0-9]+\\.)+[A-Za-z]{2}[A-Za-z]*"#
     

--- a/Tests/SuperValidatorTests/URLValidatorTests.swift
+++ b/Tests/SuperValidatorTests/URLValidatorTests.swift
@@ -15,7 +15,7 @@ internal final class URLValidatorTests: XCTestCase {
     // MARK: - Default Options
     
     internal func testValidURL_UseDefaultOptions() {
-        let url = "https://tokopedia.link/tD2jDcLZirb"
+        let url = "https://tokopedia.testingbranch.link/tD2jDcLZirb"
         let isURL = self.validator.isURL(url)
         XCTAssertTrue(isURL)
     }

--- a/Tests/SuperValidatorTests/URLValidatorTests.swift
+++ b/Tests/SuperValidatorTests/URLValidatorTests.swift
@@ -15,7 +15,7 @@ internal final class URLValidatorTests: XCTestCase {
     // MARK: - Default Options
     
     internal func testValidURL_UseDefaultOptions() {
-        let url = "https://tokopedia.tokped.asd.link/tD2jDcLZirb"
+        let url = "https://tokopedia.link/tD2jDcLZirb"
         let isURL = self.validator.isURL(url)
         XCTAssertTrue(isURL)
     }

--- a/Tests/SuperValidatorTests/URLValidatorTests.swift
+++ b/Tests/SuperValidatorTests/URLValidatorTests.swift
@@ -15,7 +15,7 @@ internal final class URLValidatorTests: XCTestCase {
     // MARK: - Default Options
     
     internal func testValidURL_UseDefaultOptions() {
-        let url = "https://www.example.com/path/test?myID=123&myName=test#Test"
+        let url = "https://tokopedia.tokped.asd.link/tD2jDcLZirb"
         let isURL = self.validator.isURL(url)
         XCTAssertTrue(isURL)
     }


### PR DESCRIPTION
Add length of TLD 2 - 63

Citate: TLDs can be anywhere from two to 63 characters long from
https://www.icann.org/en/system/files/files/ua-factsheet-a4-17dec15-en.pdf